### PR TITLE
fix: add @Path annotation to enable personalized endpoint

### DIFF
--- a/01-hello-world/src/main/java/com/example/ecommerce/SimpleGreetResource.java
+++ b/01-hello-world/src/main/java/com/example/ecommerce/SimpleGreetResource.java
@@ -49,6 +49,7 @@ public class SimpleGreetResource {
         return message;
     }
 
+    @Path("/{name}")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Counted(name = PERSONALIZED_GETS_COUNTER_NAME,


### PR DESCRIPTION
While following the DDD workshop provided by Otávio (https://o-s-expert.github.io/ddd-workshop
), I noticed that the personalized greeting endpoint could not be accessed. I was not able to build the project before this fix.

The root cause was a missing @Path("/{name}") annotation on the getMessage method in SimpleGreetResource.